### PR TITLE
Implemented save to/load from current_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,10 +69,13 @@ camilla_port: 1234
 port: 5000
 config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"
+current_config: "~/camilladsp/configs/current_config.yaml"
 ```
 The included configuration has CamillaDSP running on the same machine as the backend, with the websocket server enabled at port 1234. The web interface will be served on port 5000. It is possible to run the gui and CamillaDSP on different machines, just point the `camilla_host` to the right address.
 
-The settings for config_dir and coeff_dir point to two folders where the backend has permissions to write files. This is provided to enable uploading of coefficients and config files from the gui. 
+The settings for config_dir and coeff_dir point to two folders where the backend has permissions to write files. This is provided to enable uploading of coefficients and config files from the gui.
+
+`current_config` is the CamillaDSP config file that is loaded into the web interface when it is opened. The current settings from the web interface are also saved to this file automatically, when they are applied to CamillaDSP. Leave this setting blank, if you always want to start with the default config and not save to a default file.  
 
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The included configuration has CamillaDSP running on the same machine as the bac
 
 The settings for config_dir and coeff_dir point to two folders where the backend has permissions to write files. This is provided to enable uploading of coefficients and config files from the gui.
 
-`working_config` is the CamillaDSP config file that is loaded into the web interface when it is opened. If `save_working_config` is true, the current settings from the web interface are also saved to this file automatically, when they are applied to CamillaDSP. Leave this setting blank, if you always want to start with the default config and not save automatically.  
+`working_config` is the CamillaDSP config file that is loaded into the web interface when it is opened. Leave this setting blank, if you always want to start with the default config. If `save_working_config` is true, the current settings from the web interface are also saved to this file automatically, when they are applied to CamillaDSP. If `working_config` does not exist, it is created on the first save.  
 Note: the `working_config` will NOT be automatically applied to CamillaDSP, when CamillaDSP or the GUI starts. To have CamillaDSP use it on start, set CamillaDSP's config path to the same as `working_config`. 
 
 ## Running

--- a/README.md
+++ b/README.md
@@ -69,14 +69,15 @@ camilla_port: 1234
 port: 5000
 config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"
-current_config: "~/camilladsp/configs/current_config.yaml"
+working_config: "~/camilladsp/working_config.yaml"
+save_working_config: true
 ```
 The included configuration has CamillaDSP running on the same machine as the backend, with the websocket server enabled at port 1234. The web interface will be served on port 5000. It is possible to run the gui and CamillaDSP on different machines, just point the `camilla_host` to the right address.
 
 The settings for config_dir and coeff_dir point to two folders where the backend has permissions to write files. This is provided to enable uploading of coefficients and config files from the gui.
 
-`current_config` is the CamillaDSP config file that is loaded into the web interface when it is opened. The current settings from the web interface are also saved to this file automatically, when they are applied to CamillaDSP. Leave this setting blank, if you always want to start with the default config and not save to a default file.  
-
+`working_config` is the CamillaDSP config file that is loaded into the web interface when it is opened. If `save_working_config` is true, the current settings from the web interface are also saved to this file automatically, when they are applied to CamillaDSP. Leave this setting blank, if you always want to start with the default config and not save automatically.  
+Note: the `working_config` will NOT be automatically applied to CamillaDSP, when CamillaDSP or the GUI starts. To have CamillaDSP use it on start, set CamillaDSP's config path to the same as `working_config`. 
 
 ## Running
 Start the server with:

--- a/config/camillagui.yml
+++ b/config/camillagui.yml
@@ -4,3 +4,4 @@ camilla_port: 1234
 port: 5000
 config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"
+current_config: "~/camilladsp/configs/current_config.yaml"

--- a/config/camillagui.yml
+++ b/config/camillagui.yml
@@ -2,7 +2,7 @@
 camilla_host: "0.0.0.0"
 camilla_port: 1234
 port: 5000
-config_dir: "~/camilladsp/configs"
-coeff_dir: "~/camilladsp/coeffs"
-working_config: "~/camilladsp/working_config.yaml"
+config_dir: "configs"
+coeff_dir: "coeffs"
+working_config: "configs/working_config.yaml"
 save_working_config: true

--- a/config/camillagui.yml
+++ b/config/camillagui.yml
@@ -4,4 +4,5 @@ camilla_port: 1234
 port: 5000
 config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"
-current_config: "~/camilladsp/configs/current_config.yaml"
+working_config: "~/camilladsp/working_config.yaml"
+save_working_config: true

--- a/main.py
+++ b/main.py
@@ -7,7 +7,8 @@ import sys
 app = web.Application()
 app["config_dir"] = config["config_dir"]
 app["coeff_dir"] = config["coeff_dir"]
-app["current_config"] = config["current_config"]
+app["working_config"] = config["working_config"]
+app["save_working_config"] = config["save_working_config"]
 setup_routes(app)
 setup_static_routes(app)
 

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ import sys
 app = web.Application()
 app["config_dir"] = config["config_dir"]
 app["coeff_dir"] = config["coeff_dir"]
+app["current_config"] = config["current_config"]
 setup_routes(app)
 setup_static_routes(app)
 

--- a/routes.py
+++ b/routes.py
@@ -9,7 +9,7 @@ from views import (
     eval_pipeline_svg,
     get_config,
     set_config,
-    get_current_config_file,
+    get_working_config_file,
     config_to_yml,
     yml_to_json,
     validate_config,
@@ -38,7 +38,7 @@ def setup_routes(app):
     app.router.add_post("/api/evalpipelinesvg", eval_pipeline_svg)
     app.router.add_get("/api/getconfig", get_config)
     app.router.add_post("/api/setconfig", set_config)
-    app.router.add_get("/api/getcurrentconfigfile", get_current_config_file)
+    app.router.add_get("/api/getworkingconfigfile", get_working_config_file)
     app.router.add_post("/api/configtoyml", config_to_yml)
     app.router.add_post("/api/ymltojson", yml_to_json)
     app.router.add_post("/api/validateconfig", validate_config)

--- a/routes.py
+++ b/routes.py
@@ -9,6 +9,7 @@ from views import (
     eval_pipeline_svg,
     get_config,
     set_config,
+    get_current_config_file,
     config_to_yml,
     yml_to_json,
     validate_config,
@@ -37,6 +38,7 @@ def setup_routes(app):
     app.router.add_post("/api/evalpipelinesvg", eval_pipeline_svg)
     app.router.add_get("/api/getconfig", get_config)
     app.router.add_post("/api/setconfig", set_config)
+    app.router.add_get("/api/getcurrentconfigfile", get_current_config_file)
     app.router.add_post("/api/configtoyml", config_to_yml)
     app.router.add_post("/api/ymltojson", yml_to_json)
     app.router.add_post("/api/validateconfig", validate_config)

--- a/settings.py
+++ b/settings.py
@@ -10,6 +10,11 @@ def get_config(path):
         config = yaml.safe_load(f)
     config["config_dir"] = os.path.abspath(os.path.expanduser(config["config_dir"]))
     config["coeff_dir"] = os.path.abspath(os.path.expanduser(config["coeff_dir"]))
+    current_config = config["current_config"]
+    if current_config:
+        config["current_config"] = os.path.abspath(os.path.expanduser(current_config))
+    else:
+        config["current_config"] = None
     print(config)
     return config
 

--- a/settings.py
+++ b/settings.py
@@ -10,11 +10,11 @@ def get_config(path):
         config = yaml.safe_load(f)
     config["config_dir"] = os.path.abspath(os.path.expanduser(config["config_dir"]))
     config["coeff_dir"] = os.path.abspath(os.path.expanduser(config["coeff_dir"]))
-    current_config = config["current_config"]
-    if current_config:
-        config["current_config"] = os.path.abspath(os.path.expanduser(current_config))
+    working_config = config["working_config"]
+    if working_config:
+        config["working_config"] = os.path.abspath(os.path.expanduser(working_config))
     else:
-        config["current_config"] = None
+        config["working_config"] = None
     print(config)
     return config
 

--- a/views.py
+++ b/views.py
@@ -173,22 +173,23 @@ async def get_config(request):
 
 
 async def set_config(request):
-    current_config_file = request.app["current_config"]
     # Apply a new config to CamillaDSP
     json_config = await request.json()
     cdsp = request.app["CAMILLA"]
     cdsp.set_config(json_config)
-    # If current_config is set, save new config to current_config
-    if current_config_file:
+    # If working_config is set, save new config to working_config
+    working_config_file = request.app["working_config"]
+    save_working_config = request.app["save_working_config"]
+    if working_config_file and save_working_config:
         yaml_config = yaml.dump(json_config).encode('utf-8')
-        with open(current_config_file, "wb") as f:
+        with open(working_config_file, "wb") as f:
             f.write(yaml_config)
     return web.Response(text="OK")
 
 
-async def get_current_config_file(request):
-    current_config_file = request.app["current_config"]
-    with open(current_config_file, 'r') as file:
+async def get_working_config_file(request):
+    working_config_file = request.app["working_config"]
+    with open(working_config_file, 'r') as file:
         cdsp = request.app["CAMILLA"]
         yaml_config = file.read()
         json_config = cdsp.read_config(yaml_config)

--- a/views.py
+++ b/views.py
@@ -173,11 +173,26 @@ async def get_config(request):
 
 
 async def set_config(request):
+    current_config_file = request.app["current_config"]
     # Apply a new config to CamillaDSP
-    content = await request.json()
+    json_config = await request.json()
     cdsp = request.app["CAMILLA"]
-    cdsp.set_config(content)
+    cdsp.set_config(json_config)
+    # If current_config is set, save new config to current_config
+    if current_config_file:
+        yaml_config = yaml.dump(json_config).encode('utf-8')
+        with open(current_config_file, "wb") as f:
+            f.write(yaml_config)
     return web.Response(text="OK")
+
+
+async def get_current_config_file(request):
+    current_config_file = request.app["current_config"]
+    with open(current_config_file, 'r') as file:
+        cdsp = request.app["CAMILLA"]
+        yaml_config = file.read()
+        json_config = cdsp.read_config(yaml_config)
+        return web.json_response(json_config)
 
 
 async def config_to_yml(request):


### PR DESCRIPTION
This is part of the implementation of #8.

This includes:
- a configuration option for `current_config` file.
- an API endpoint `/api/getcurrentconfigfile` to retrieve the content of `current_config`
    - throws Error 500, if `current_config` cannot be read
- if `current_config` is set, calling `/api/setconfig` automatically writes to it
    - throws Error 500, if `current_config` cannot be written
    - creates `current_config` file, if it doesn't already exist
- changes to the documentation