### PR TITLE
Gui without cdsp instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"
 working_config: "~/camilladsp/working_config.yaml"
 save_working_config: true
+backup_camilla_path: ""
+backup_camilla_port: 1235
 ```
 The included configuration has CamillaDSP running on the same machine as the backend, with the websocket server enabled at port 1234. The web interface will be served on port 5000. It is possible to run the gui and CamillaDSP on different machines, just point the `camilla_host` to the right address.
 
@@ -80,6 +82,10 @@ The settings for config_dir and coeff_dir point to two folders where the backend
 
 `working_config` is the CamillaDSP config file that is loaded into the web interface when it is opened. Leave this setting blank, if you always want to start with the default config. If `save_working_config` is true, the current settings from the web interface are also saved to this file automatically, when they are applied to CamillaDSP. If `working_config` does not exist, it is created on the first save.  
 Note: the `working_config` will NOT be automatically applied to CamillaDSP, when CamillaDSP or the GUI starts. To have CamillaDSP use it on start, set CamillaDSP's config path to the same as `working_config`. 
+
+If the CamillaDSP instance at `camilla_host`:`camilla_port` is not always available, a backup instance can be configured.
+This allows several gui features to work, even if the primary CamillaDSP is not running.
+It is started together with the backend and used when appropriate. 
 
 #### Hiding GUI Options
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ Download the zip-file ("camillagui.zip") for the latest release. This includes b
 
 Unzip the file, and edit `config/camillagui.yml` if needed.
 
+#### Configuration
+
 ```yaml
 ---
 camilla_host: "0.0.0.0"
@@ -78,6 +80,18 @@ The settings for config_dir and coeff_dir point to two folders where the backend
 
 `working_config` is the CamillaDSP config file that is loaded into the web interface when it is opened. Leave this setting blank, if you always want to start with the default config. If `save_working_config` is true, the current settings from the web interface are also saved to this file automatically, when they are applied to CamillaDSP. If `working_config` does not exist, it is created on the first save.  
 Note: the `working_config` will NOT be automatically applied to CamillaDSP, when CamillaDSP or the GUI starts. To have CamillaDSP use it on start, set CamillaDSP's config path to the same as `working_config`. 
+
+#### Hiding GUI Options
+
+If you want to integrate CamillaGUI with other software and hide some options from your users,
+this is possible through `config/gui-config.yml`.
+Setting any of the options to `true` hides the corresponding option or section. 
+```yaml
+hide_capture_samplerate: false
+hide_silence: false
+hide_capture_device: false
+hide_playback_device: false
+```
 
 ## Running
 Start the server with:

--- a/config/camillagui.yml
+++ b/config/camillagui.yml
@@ -6,3 +6,5 @@ config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"
 working_config: "~/camilladsp/working_config.yaml"
 save_working_config: true
+backup_camilla_path: ""
+backup_camilla_port: 1235

--- a/config/gui-config.yml
+++ b/config/gui-config.yml
@@ -1,0 +1,4 @@
+  hide_capture_samplerate: false
+  hide_silence: false
+  hide_capture_device: false
+  hide_playback_device: false

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from aiohttp import web
 from camilladsp import CamillaConnection
+from offline import start_backup_cdsp
 from settings import config
 from routes import setup_routes, setup_static_routes
 import sys
@@ -30,6 +31,6 @@ if len(sys.argv) > 1 and sys.argv[1] == "debug":
 camillaconnection = CamillaConnection(config["camilla_host"], config["camilla_port"])
 #camillaconnection.connect()
 app['CAMILLA'] = camillaconnection
-backupCamillaconnection = CamillaConnection("127.0.0.1", config["backup_camilla_port"])
-app["BACKUP-CAMILLA"] = backupCamillaconnection
+app["BACKUP-CAMILLA"] = CamillaConnection("127.0.0.1", config["backup_camilla_port"])
+start_backup_cdsp(config)
 web.run_app(app, port=config["port"])

--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ app["save_working_config"] = config["save_working_config"]
 setup_routes(app)
 setup_static_routes(app)
 
-if len(sys.argv)>1 and sys.argv[1] == "debug":
+if len(sys.argv) > 1 and sys.argv[1] == "debug":
     # Add CORS to allow all, for testing only!
     import aiohttp_cors
     cors = aiohttp_cors.setup(app, defaults={
@@ -30,4 +30,6 @@ if len(sys.argv)>1 and sys.argv[1] == "debug":
 camillaconnection = CamillaConnection(config["camilla_host"], config["camilla_port"])
 #camillaconnection.connect()
 app['CAMILLA'] = camillaconnection
+backupCamillaconnection = CamillaConnection("127.0.0.1", config["backup_camilla_port"])
+app["BACKUP-CAMILLA"] = backupCamillaconnection
 web.run_app(app, port=config["port"])

--- a/offline.py
+++ b/offline.py
@@ -1,0 +1,30 @@
+import subprocess
+
+
+def start_backup_cdsp(config):
+    backup_cdsp_path = config["backup_camilla_path"]
+    backup_cdsp_port = config["backup_camilla_port"]
+    if backup_cdsp_path and backup_cdsp_port:
+        subprocess.Popen([backup_cdsp_path, "-p", str(backup_cdsp_port), "-w"])
+
+
+def backup_cdsp(request):
+    backup = request.app["BACKUP-CAMILLA"]
+    if not backup.is_connected():
+        try:
+            backup.connect()
+        except ConnectionRefusedError as e:
+            print(e)
+    if backup.is_connected():
+        return backup
+    else:
+        return None
+
+
+def cdsp_or_backup_cdsp(request):
+    cdsp = request.app["CAMILLA"]
+    if not cdsp.is_connected():
+        backup = backup_cdsp(request)
+        if backup:
+            return backup
+    return cdsp

--- a/routes.py
+++ b/routes.py
@@ -50,7 +50,7 @@ def setup_routes(app):
     app.router.add_get("/api/storedcoeffs", get_stored_coeffs)
     app.router.add_post("/api/uploadconfig", store_config)
     app.router.add_post("/api/uploadcoeff", store_coeff)
-    app.router.add_get("/api/gui-config.json", get_gui_config)
+    app.router.add_get("/api/guiconfig", get_gui_config)
 
     app.router.add_get("/", get_gui_index)
 

--- a/routes.py
+++ b/routes.py
@@ -20,7 +20,8 @@ from views import (
     get_stored_coeffs,
     get_stored_configs,
     store_config,
-    store_coeff
+    store_coeff,
+    get_gui_config
 )
 import pathlib
 
@@ -49,6 +50,7 @@ def setup_routes(app):
     app.router.add_get("/api/storedcoeffs", get_stored_coeffs)
     app.router.add_post("/api/uploadconfig", store_config)
     app.router.add_post("/api/uploadcoeff", store_coeff)
+    app.router.add_get("/api/gui-config.json", get_gui_config)
 
     app.router.add_get("/", get_gui_index)
 

--- a/settings.py
+++ b/settings.py
@@ -1,7 +1,6 @@
 import pathlib
 import yaml
 import os
-import subprocess
 
 
 BASEPATH = pathlib.Path(__file__).parent.absolute()
@@ -27,12 +26,4 @@ def absolute_path_or_none_if_empty(path):
         return None
 
 
-def start_backup_cdsp(config):
-    backup_cdsp_path = config["backup_camilla_path"]
-    backup_cdsp_port = config["backup_camilla_port"]
-    if backup_cdsp_path and backup_cdsp_port:
-        subprocess.Popen([backup_cdsp_path, "-p", str(backup_cdsp_port), "-w"])
-
-
 config = get_config(config_path)
-start_backup_cdsp(config)

--- a/settings.py
+++ b/settings.py
@@ -4,6 +4,7 @@ import os
 
 BASEPATH = pathlib.Path(__file__).parent.absolute()
 config_path = BASEPATH/ 'config' / 'camillagui.yml'
+gui_config_path = BASEPATH/ 'config' / 'gui-config.yml'
 
 def get_config(path):
     with open(path) as f:

--- a/settings.py
+++ b/settings.py
@@ -1,22 +1,38 @@
 import pathlib
 import yaml
 import os
+import subprocess
+
 
 BASEPATH = pathlib.Path(__file__).parent.absolute()
 config_path = BASEPATH/ 'config' / 'camillagui.yml'
 gui_config_path = BASEPATH/ 'config' / 'gui-config.yml'
+
 
 def get_config(path):
     with open(path) as f:
         config = yaml.safe_load(f)
     config["config_dir"] = os.path.abspath(os.path.expanduser(config["config_dir"]))
     config["coeff_dir"] = os.path.abspath(os.path.expanduser(config["coeff_dir"]))
-    working_config = config["working_config"]
-    if working_config:
-        config["working_config"] = os.path.abspath(os.path.expanduser(working_config))
-    else:
-        config["working_config"] = None
+    config["working_config"] = absolute_path_or_none_if_empty(config["working_config"])
+    config["backup_camilla_path"] = absolute_path_or_none_if_empty(config["backup_camilla_path"])
     print(config)
     return config
 
+
+def absolute_path_or_none_if_empty(path):
+    if path:
+        return os.path.abspath(os.path.expanduser(path))
+    else:
+        return None
+
+
+def start_backup_cdsp(config):
+    backup_cdsp_path = config["backup_camilla_path"]
+    backup_cdsp_port = config["backup_camilla_port"]
+    if backup_cdsp_path and backup_cdsp_port:
+        subprocess.Popen([backup_cdsp_path, "-p", str(backup_cdsp_port), "-w"])
+
+
 config = get_config(config_path)
+start_backup_cdsp(config)

--- a/views.py
+++ b/views.py
@@ -1,5 +1,6 @@
 from aiohttp import web
 from camilladsp import CamillaError
+from offline import cdsp_or_backup_cdsp, backup_cdsp
 from settings import gui_config_path
 
 try:
@@ -195,28 +196,6 @@ async def set_config(request):
         with open(working_config_file, "wb") as f:
             f.write(yaml_config)
     return web.Response(text="OK")
-
-
-def backup_cdsp(request):
-    backup = request.app["BACKUP-CAMILLA"]
-    if not backup.is_connected():
-        try:
-            backup.connect()
-        except ConnectionRefusedError as e:
-            print(e)
-    if backup.is_connected():
-        return backup
-    else:
-        return None
-
-
-def cdsp_or_backup_cdsp(request):
-    cdsp = request.app["CAMILLA"]
-    if not cdsp.is_connected():
-        backup = backup_cdsp(request)
-        if backup:
-            return backup
-    return cdsp
 
 
 async def get_working_config_file(request):

--- a/views.py
+++ b/views.py
@@ -1,5 +1,7 @@
 from aiohttp import web
 from camilladsp import CamillaError
+from settings import gui_config_path
+
 try:
     from camilladsp_plot import plot_pipeline, plot_filter, plot_filterstep
     PLOTTING = True
@@ -59,6 +61,7 @@ async def get_param(request):
     print(result)
     return web.Response(text=str(result))
 
+
 async def get_list_param(request):
     # Get a parameter value as a list
     name = request.match_info["name"]
@@ -112,6 +115,7 @@ async def eval_filter_svg(request):
         image = SVG_PLACEHOLDER
     return web.Response(body=image, content_type="image/svg+xml")
 
+
 async def eval_filter_values(request):
     # Plot a filter
     content = await request.json()
@@ -140,6 +144,7 @@ async def eval_filterstep_svg(request):
     else:
         image = SVG_PLACEHOLDER
     return web.Response(body=image, content_type="image/svg+xml")
+
 
 async def eval_filterstep_values(request):
     # Plot a filter
@@ -228,15 +233,18 @@ async def get_version(request):
     version = {"major": vers_tup[0], "minor": vers_tup[1], "patch": vers_tup[2]}
     return web.json_response(version)
 
+
 async def get_library_version(request):
     cdsp = request.app["CAMILLA"]
     vers_tup = cdsp.get_library_version()
     version = {"major": vers_tup[0], "minor": vers_tup[1], "patch": vers_tup[2]}
     return web.json_response(version)
 
+
 async def get_backend_version(request):
     version = {"major": VERSION[0], "minor": VERSION[1], "patch": VERSION[2]}
     return web.json_response(version)
+
 
 async def store_coeff(request):
     data = await request.post()
@@ -251,6 +259,7 @@ async def store_coeff(request):
         text="Saved coeff file {} of {} bytes".format(filename, len(content))
     )
 
+
 async def store_config(request):
     data = await request.post()
     config = data["contents"]
@@ -264,6 +273,7 @@ async def store_config(request):
         text="Saved config file {} of {} bytes".format(filename, len(content))
     )
 
+
 async def get_stored_configs(request):
     config_dir = request.app["config_dir"]
     files = [os.path.abspath(os.path.join(config_dir, f)) for f in os.listdir(config_dir) if os.path.isfile(os.path.join(config_dir, f))]
@@ -272,6 +282,7 @@ async def get_stored_configs(request):
         fname = os.path.basename(f)
         files_dict[fname] = f 
     return web.json_response(files_dict)
+
 
 async def get_stored_coeffs(request):
     coeff_dir = request.app["coeff_dir"]
@@ -283,3 +294,8 @@ async def get_stored_coeffs(request):
         files_dict[fname] = f 
     return web.json_response(files_dict)
 
+
+async def get_gui_config(request):
+    with open(gui_config_path) as yaml_config:
+        json_config = yaml.safe_load(yaml_config)
+    return web.json_response(json_config)


### PR DESCRIPTION
Made GUI work without running CDSP instance, specifically:
- load/save working_config
- load config from a local file
- config status

This Fixes #13.
Only the last commit is relevant to this pull request - other commits are from #14.