### PR TITLE
Removed CORS hack for development

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ from camilladsp import CamillaConnection
 from offline import start_backup_cdsp
 from settings import config
 from routes import setup_routes, setup_static_routes
-import sys
 
 app = web.Application()
 app["config_dir"] = config["config_dir"]
@@ -12,21 +11,6 @@ app["default_config"] = config["default_config"]
 app["active_config"] = config["active_config"]
 setup_routes(app)
 setup_static_routes(app)
-
-if len(sys.argv) > 1 and sys.argv[1] == "debug":
-    # Add CORS to allow all, for testing only!
-    import aiohttp_cors
-    cors = aiohttp_cors.setup(app, defaults={
-        "*": aiohttp_cors.ResourceOptions(
-                allow_credentials=True,
-                expose_headers="*",
-                allow_headers="*",
-            )
-    })
-    # Configure CORS on all routes.
-    for route in list(app.router.routes()):
-        cors.add(route)
-    print("WARNING: Allowing all requests! Use this for debugging only!")
 
 camillaconnection = CamillaConnection(config["camilla_host"], config["camilla_port"])
 #camillaconnection.connect()


### PR DESCRIPTION
It is not necessary anymore, since the use of the backend proxy in the client (https://github.com/HEnquist/camillagui/pull/37)

