### PR TITLE
Config must be set to active explicitly

### DIFF
--- a/filemanagement.py
+++ b/filemanagement.py
@@ -96,9 +96,8 @@ def set_as_active_config(active_config, file):
     os.symlink(file, active_config)
 
 
-def save_to_active_config(json_config, request):
-    active_config_file = request.app["active_config"]
-    if active_config_file and islink(active_config_file):
-        yaml_config = yaml.dump(json_config).encode('utf-8')
-        with open(active_config_file, "wb") as f:
-            f.write(yaml_config)
+def save_config(config_name, json_config, request):
+    config_file = path_of_configfile(request, config_name)
+    yaml_config = yaml.dump(json_config).encode('utf-8')
+    with open(config_file, "wb") as f:
+        f.write(yaml_config)

--- a/routes.py
+++ b/routes.py
@@ -10,6 +10,7 @@ from views import (
     get_config,
     set_config,
     get_active_config_file,
+    set_active_config_name,
     config_to_yml,
     yml_to_json,
     validate_config,
@@ -46,6 +47,7 @@ def setup_routes(app):
     app.router.add_get("/api/getconfig", get_config)
     app.router.add_post("/api/setconfig", set_config)
     app.router.add_get("/api/getactiveconfigfile", get_active_config_file)
+    app.router.add_post("/api/setactiveconfigfile", set_active_config_name)
     app.router.add_post("/api/configtoyml", config_to_yml)
     app.router.add_post("/api/ymltojson", yml_to_json)
     app.router.add_post("/api/validateconfig", validate_config)


### PR DESCRIPTION
Config is not marked as active on save/load anymore.
It must be set to active explicitly via setactiveconfigfile endpoint.