### PR TITLE
coeff_dir in GUI is now relative to config_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is the server part of CamillaGUI, a web-based GUI for CamillaDSP.
 
-This version works with CamillaDSP 0.4.0 and up.
+This version works with CamillaDSP 0.5.0 and up.
 
 The complete GUI is made up of two parts:
 - a frontend based on React: https://reactjs.org/
@@ -15,20 +15,14 @@ Install the dependencies:
 - websocket-client (required by pycamilladsp)
 - aiohttp
 
-For plotting, install these optional dependencies:
-- numpy (required by pycamilladsp-plot)
-- matplotlib (required by pycamilladsp-plot)
-
-
-
 These are the names of the packages needed:
-| Distribution | python | websocket-client | aiohttp | matplotlib | numpy |
-|--------------|--------|------------------|-------|------------|---------|
-| Fedora | python3 | python3-websocket-client | python3-aiohttp | python3-matplotlib | python3-numpy  |
-| Debian/Raspbian | python3 | python3-websocket | python3-aiohttp | python3-matplotlib | python3-numpy |
-| Arch | python | python-websocket-client | python-aiohttp | python-matplotlib | python-numpy |
-| pip | - | websocket_client | aiohttp | matplotlib | numpy |
-| Anaconda | - | websocket_client | aiohttp | matplotlib | numpy |
+| Distribution | python | websocket-client | aiohttp |
+|--------------|--------|------------------|-------|
+| Fedora | python3 | python3-websocket-client | python3-aiohttp |
+| Debian/Raspbian | python3 | python3-websocket | python3-aiohttp |
+| Arch | python | python-websocket-client | python-aiohttp |
+| pip | - | websocket_client | aiohttp |
+| Anaconda | - | websocket_client | aiohttp |
 
 #### Linux
 Most linux distributions have Python 3.6 or newer installed by default. Use the normal package manager to install the packages.

--- a/routes.py
+++ b/routes.py
@@ -1,11 +1,11 @@
+import pathlib
+
 from views import (
     get_param,
     get_list_param,
     set_param,
     eval_filter_values,
     eval_filterstep_values,
-    eval_filter_svg,
-    eval_filterstep_svg,
     eval_pipeline_svg,
     get_config,
     set_config,
@@ -30,7 +30,6 @@ from views import (
     get_config_file,
     save_config_file
 )
-import pathlib
 
 BASEPATH = pathlib.Path(__file__).parent.absolute()
 
@@ -39,8 +38,6 @@ def setup_routes(app):
     app.router.add_get("/api/getparam/{name}", get_param)
     app.router.add_get("/api/getlistparam/{name}", get_list_param)
     app.router.add_post("/api/setparam/{name}", set_param)
-    app.router.add_post("/api/evalfiltersvg", eval_filter_svg)
-    app.router.add_post("/api/evalfilterstepsvg", eval_filterstep_svg)
     app.router.add_post("/api/evalfilter", eval_filter_values)
     app.router.add_post("/api/evalfilterstep", eval_filterstep_values)
     app.router.add_post("/api/evalpipelinesvg", eval_pipeline_svg)

--- a/routes.py
+++ b/routes.py
@@ -6,7 +6,6 @@ from views import (
     set_param,
     eval_filter_values,
     eval_filterstep_values,
-    eval_pipeline_svg,
     get_config,
     set_config,
     get_active_config_file,
@@ -40,7 +39,6 @@ def setup_routes(app):
     app.router.add_post("/api/setparam/{name}", set_param)
     app.router.add_post("/api/evalfilter", eval_filter_values)
     app.router.add_post("/api/evalfilterstep", eval_filterstep_values)
-    app.router.add_post("/api/evalpipelinesvg", eval_pipeline_svg)
     app.router.add_get("/api/getconfig", get_config)
     app.router.add_post("/api/setconfig", set_config)
     app.router.add_get("/api/getactiveconfigfile", get_active_config_file)

--- a/views.py
+++ b/views.py
@@ -1,7 +1,9 @@
 from os.path import isfile
 
+import yaml
 from aiohttp import web
 from camilladsp import CamillaError
+from camilladsp_plot import eval_filter, eval_filterstep
 
 from filemanagement import (
     path_of_configfile, store_files, list_of_files_in_directory, delete_files,
@@ -11,14 +13,6 @@ from filemanagement import (
 )
 from offline import cdsp_or_backup_cdsp, set_cdsp_config_or_validate_with_backup_cdsp
 from settings import gui_config_path
-
-try:
-    from camilladsp_plot import plot_pipeline, eval_filter, eval_filterstep
-    PLOTTING = True
-except ImportError:
-    print("No plotting!")
-    PLOTTING = False
-import yaml
 from version import VERSION
 
 SVG_PLACEHOLDER = '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><text x="20" y="40">Plotting not available!</text></svg>'
@@ -134,16 +128,6 @@ async def eval_filterstep_values(request):
         npoints=1000,
     )
     return web.json_response(data)
-
-
-async def eval_pipeline_svg(request):
-    # Plot a pipeline
-    if PLOTTING:
-        content = await request.json()
-        image = plot_pipeline(content, toimage=True)
-    else:
-        image = SVG_PLACEHOLDER
-    return web.Response(body=image, content_type="image/svg+xml")
 
 
 async def get_config(request):


### PR DESCRIPTION
- filter paths in the GUI and stored in the backend are now relative
- on config/active_config load filter paths are converted to relative
- for filter/pipeline_step plot filter paths are converted to absolute

I also removed unused filter and pipeline step routes and corresponding functions.

Fixes #19 

@HEnquist please have a look.
Loading of configs with absolute and relative convolution filter files should work.
Plotting of filters and pipeline steps should work for files with absolute and relative filter files.