### PR TITLE
add project file for poetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "camillagui-backend"
+version = "2.0.0-alpha3"
+description = "Backend server for CamillaGUI"
+authors = ["Henrik Enquist <henrik.enquist@gmail.com>"]
+license = "GPLv3"
+readme = "README.md"
+
+[tool.poetry.dependencies]
+python = "^3.8"
+websocket-client = "^1.6.4"
+jsonschema = "^4.20.0"
+aiohttp = "^3.9.0"
+camilladsp = {git = "https://github.com/HEnquist/pycamilladsp.git", rev = "v1.0.0"}
+camilladsp-plot = {git = "https://github.com/HEnquist/pycamilladsp-plot.git", rev = "v1.0.2"}
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
makes it possible to start camillagui-backend with just `poetry run python main.py`

before just run `poetry update`

because install cmds from `README.md` do not work anymore (debian sid)
```
error: externally-managed-environment
hint: See PEP 668 for the detailed specification.
```