### PR TITLE
[CRITICAL] Add backend bind address configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The backend configuration is stored in `config/camillagui.yml`
 ---
 camilla_host: "0.0.0.0"
 camilla_port: 1234
+bind_address: "0.0.0.0"
 port: 5000
 config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"
@@ -55,6 +56,8 @@ supported_capture_types: null (*)
 supported_playback_types: null (*)
 ```
 The options marked `(*)` are optional. If left out the default values listed above will be used. The included configuration has CamillaDSP running on the same machine as the backend, with the websocket server enabled at port 1234. The web interface will be served on port 5000. It is possible to run the gui and CamillaDSP on different machines, just point the `camilla_host` to the right address.
+
+**Warning**: By default the backend will bind to all networks and this may be insecure. Make sure to change the `bind_address` if you want it to be reachable only on specific network interface(s) and/or to set your firewall to block external (internet) access to this backend.
 
 The settings for config_dir and coeff_dir point to two folders where the backend has permissions to write files. This is provided to enable uploading of coefficients and config files from the gui.
 

--- a/config/camillagui.yml
+++ b/config/camillagui.yml
@@ -1,6 +1,7 @@
 ---
 camilla_host: "127.0.0.1"
 camilla_port: 1234
+bind_address: "0.0.0.0"
 port: 5005
 config_dir: "~/camilladsp/configs"
 coeff_dir: "~/camilladsp/coeffs"

--- a/main.py
+++ b/main.py
@@ -53,4 +53,4 @@ if config["supported_capture_types"] is not None:
 if config["supported_playback_types"] is not None:
     camillavalidator.set_supported_playback_types(config["supported_playback_types"])
 app["VALIDATOR"] = camillavalidator
-web.run_app(app, port=config["port"])
+web.run_app(app, host=config["bind_address"], port=config["port"])


### PR DESCRIPTION
Add a "bind_address" configuration entry and make it default to all interfaces (0.0.0.0) to not change the old default behavior.

This is important as making the CamillaDSP GUI backend reachable from all networks may be a rather important security concern for multiple reasons.
While at it, also document the new parameter in the README.md file.
