### PR TITLE
Fix KeyError when migrating configs with Wav or Values convolvers

### DIFF
--- a/backend/legacy_config_import.py
+++ b/backend/legacy_config_import.py
@@ -146,9 +146,11 @@ def _modify_conv_filters(config):
     if "filters" in config:
         for _name, filt in config["filters"].items():
             if filt["type"] == "Conv":
-                filt["parameters"]["format"] = _map_format(
-                    None, filt["parameters"]["format"]
-                )
+                # Only Raw (and legacy File) convolvers have a format parameter,
+                # Wav and Values convolvers do not.
+                fmt = filt["parameters"].get("format")
+                if fmt is not None:
+                    filt["parameters"]["format"] = _map_format(None, fmt)
 
 
 def _modify_device_sample_format(dev):

--- a/tests/test_legacy_config.py
+++ b/tests/test_legacy_config.py
@@ -203,3 +203,27 @@ def test_merge_mixer_mappings(basic_config):
             ],
         }
     )
+
+
+def test_conv_filters():
+    # Wav (and Values) convolvers have no format parameter and must not
+    # crash the migration, while Raw convolver formats get renamed.
+    config = {
+        "filters": {
+            "fir_wav": {
+                "type": "Conv",
+                "parameters": {"type": "Wav", "filename": "fir.wav", "channel": 0},
+            },
+            "fir_raw": {
+                "type": "Conv",
+                "parameters": {
+                    "type": "Raw",
+                    "filename": "fir.dat",
+                    "format": "FLOAT32LE",
+                },
+            },
+        }
+    }
+    migrate_legacy_config(config)
+    assert "format" not in config["filters"]["fir_wav"]["parameters"]
+    assert config["filters"]["fir_raw"]["parameters"]["format"] == "F32_LE"


### PR DESCRIPTION
## Problem

`migrate_legacy_config` crashes with `KeyError: 'format'` on any config containing `Conv` filters of type `Wav` (or `Values`), because `_modify_conv_filters` reads the `format` parameter unconditionally:

```python
filt["parameters"]["format"] = _map_format(None, filt["parameters"]["format"])
```

Only `Raw` (and legacy `File`) convolvers have a `format` parameter; `Wav` and `Values` do not.

Since `/api/ymltojson` always runs the migration, this breaks the GUI's *Import config* feature for every config that uses WAV convolution filters. The GUI surfaces it as the generic `Could not extract filters from file` error (camillagui `src/import/configimport.ts`), with no hint of the actual cause.

### Reproduction

1. Create a config with a filter such as:
   ```yaml
   filters:
     fir_l:
       type: Conv
       parameters:
         type: Wav
         filename: "fir_l.wav"
   ```
2. In the GUI, use Import config and select the file.
3. Backend raises `KeyError: 'format'`, request returns 500, GUI shows "Could not extract filters from file".

## Fix

Only rename the format when the parameter is present:

```python
fmt = filt["parameters"].get("format")
if fmt is not None:
    filt["parameters"]["format"] = _map_format(None, fmt)
```

## Tests

Added `test_conv_filters` covering both a `Wav` convolver (must pass through untouched, no `format` key added) and a `Raw` convolver (`FLOAT32LE` renamed to `F32_LE`). The new test fails with `KeyError: 'format'` on current master and passes with this fix; the full `tests/test_legacy_config.py` suite passes.